### PR TITLE
data/presets: add surveillance and camera related properties

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -206,6 +206,21 @@ en:
       building_area:
         # building=*
         label: Building
+      camera/features:
+        # 'camera:features=*'
+        label: Camera features
+        # camera/features field placeholder
+        placeholder: 'Webcam, Microphone, Nightvision, Heatvision, Zoom, Motion, Wireless'
+      camera/mount:
+        # 'camera:mount=*'
+        label: Camera mount
+        # camera/mount field placeholder
+        placeholder: 'Wall, Pole'
+      camera/type:
+        # 'camera:type=*'
+        label: Camera type
+        # camera/type field placeholder
+        placeholder: 'Fixed, Panning, Dome'
       capacity:
         # capacity=*
         label: Capacity
@@ -261,6 +276,11 @@ en:
       construction:
         # construction=*
         label: Type
+      contact/webcam:
+        # 'contact:webcam=*'
+        label: Webcam feed URL
+        # contact/webcam field placeholder
+        placeholder: 'http://example.com/'
       content:
         # content=*
         label: Contents
@@ -1062,6 +1082,21 @@ en:
       surface:
         # surface=*
         label: Surface
+      surveillance:
+        # surveillance=*
+        label: Surveillance kind
+        # surveillance field placeholder
+        placeholder: 'Public, Outdoor, Indoor'
+      surveillance/type:
+        # 'surveillance:type=*'
+        label: What is watching
+        # surveillance/type field placeholder
+        placeholder: 'Camera, Guard, ALPR'
+      surveillance/zone:
+        # 'surveillance:zone=*'
+        label: Zone
+        # surveillance/zone field placeholder
+        placeholder: 'Town, Parking, Traffic, Shop, Building'
       tactile_paving:
         # tactile_paving=*
         label: Tactile Paving

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -283,6 +283,30 @@
             "type": "combo",
             "label": "Building"
         },
+        "camera/features": {
+            "key": "camera:features",
+            "type": "combo",
+            "label": "Camera features",
+            "placeholder": "Webcam, Microphone, Nightvision, Heatvision, Zoom, Motion, Wireless"
+        },
+        "camera/mount": {
+            "key": "camera:mount",
+            "type": "combo",
+            "label": "Camera mount",
+            "placeholder": "Wall, Pole"
+        },
+        "camera/type": {
+            "key": "camera:type",
+            "type": "combo",
+            "label": "Camera type",
+            "default": "fixed",
+            "placeholder": "Fixed, Panning, Dome",
+            "options": [
+                "fixed",
+                "panning",
+                "dome"
+            ]
+        },
         "capacity": {
             "key": "capacity",
             "type": "number",
@@ -334,6 +358,14 @@
             "key": "construction",
             "type": "combo",
             "label": "Type"
+        },
+        "contact/webcam": {
+            "key": "contact:webcam",
+            "type": "url",
+            "icon": "website",
+            "placeholder": "http://example.com/",
+            "universal": true,
+            "label": "Webcam feed URL"
         },
         "content": {
             "key": "content",
@@ -1444,6 +1476,36 @@
             "key": "surface",
             "type": "combo",
             "label": "Surface"
+        },
+        "surveillance": {
+            "key": "surveillance",
+            "type": "combo",
+            "label": "Surveillance kind",
+            "default": "outdoor",
+            "placeholder": "Public, Outdoor, Indoor",
+            "options": [
+                "public",
+                "outdoor",
+                "indoor"
+            ]
+        },
+        "surveillance/type": {
+            "key": "surveillance:type",
+            "type": "combo",
+            "label": "What is watching",
+            "default": "camera",
+            "placeholder": "Camera, Guard, ALPR",
+            "options": [
+                "camera",
+                "guard",
+                "alpr"
+            ]
+        },
+        "surveillance/zone": {
+            "key": "surveillance:zone",
+            "type": "combo",
+            "label": "Zone",
+            "placeholder": "Town, Parking, Traffic, Shop, Building"
         },
         "tactile_paving": {
             "key": "tactile_paving",

--- a/data/presets/fields/camera/features.json
+++ b/data/presets/fields/camera/features.json
@@ -1,0 +1,6 @@
+{
+    "key": "camera:features",
+    "type": "combo",
+    "label": "Camera features",
+    "placeholder": "Webcam, Microphone, Nightvision, Heatvision, Zoom, Motion, Wireless"
+}

--- a/data/presets/fields/camera/mount.json
+++ b/data/presets/fields/camera/mount.json
@@ -1,0 +1,6 @@
+{
+    "key": "camera:mount",
+    "type": "combo",
+    "label": "Camera mount",
+    "placeholder": "Wall, Pole"
+}

--- a/data/presets/fields/camera/type.json
+++ b/data/presets/fields/camera/type.json
@@ -1,0 +1,8 @@
+{
+    "key": "camera:type",
+    "type": "combo",
+    "label": "Camera type",
+    "default": "fixed",
+    "placeholder": "Fixed, Panning, Dome",
+    "options": ["fixed", "panning", "dome"]
+}

--- a/data/presets/fields/contact/webcam.json
+++ b/data/presets/fields/contact/webcam.json
@@ -1,0 +1,8 @@
+{
+    "key": "contact:webcam",
+    "type": "url",
+    "icon": "website",
+    "placeholder": "http://example.com/",
+    "universal": true,
+    "label": "Webcam feed URL"
+}

--- a/data/presets/fields/surveillance.json
+++ b/data/presets/fields/surveillance.json
@@ -1,0 +1,8 @@
+{
+    "key": "surveillance",
+    "type": "combo",
+    "label": "Surveillance kind",
+    "default": "outdoor",
+    "placeholder": "Public, Outdoor, Indoor",
+    "options": ["public", "outdoor", "indoor"]
+}

--- a/data/presets/fields/surveillance/type.json
+++ b/data/presets/fields/surveillance/type.json
@@ -1,0 +1,8 @@
+{
+    "key": "surveillance:type",
+    "type": "combo",
+    "label": "What is watching",
+    "default": "camera",
+    "placeholder": "Camera, Guard, ALPR",
+    "options": ["camera", "guard", "alpr"]
+}

--- a/data/presets/fields/surveillance/zone.json
+++ b/data/presets/fields/surveillance/zone.json
@@ -1,0 +1,6 @@
+{
+    "key": "surveillance:zone",
+    "type": "combo",
+    "label": "Zone",
+    "placeholder": "Town, Parking, Traffic, Shop, Building"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -6952,6 +6952,13 @@
             "geometry": [
                 "point"
             ],
+            "fields": [
+                "surveillance",
+                "surveillance/type",
+                "camera/type",
+                "camera/mount",
+                "surveillance/zone"
+            ],
             "terms": [
                 "anpr",
                 "alpr",

--- a/data/presets/presets/man_made/surveillance.json
+++ b/data/presets/presets/man_made/surveillance.json
@@ -3,6 +3,13 @@
     "geometry": [
         "point"
     ],
+    "fields": [
+        "surveillance",
+        "surveillance/type",
+        "camera/type",
+        "camera/mount",
+        "surveillance/zone"
+     ],
     "terms": [
         "anpr",
         "alpr",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -820,6 +820,18 @@
                 "building": {
                     "label": "Building"
                 },
+                "camera/features": {
+                    "label": "Camera features",
+                    "placeholder": "Webcam, Microphone, Nightvision, Heatvision, Zoom, Motion, Wireless"
+                },
+                "camera/mount": {
+                    "label": "Camera mount",
+                    "placeholder": "Wall, Pole"
+                },
+                "camera/type": {
+                    "label": "Camera type",
+                    "placeholder": "Fixed, Panning, Dome"
+                },
                 "capacity": {
                     "label": "Capacity",
                     "placeholder": "50, 100, 200..."
@@ -857,6 +869,10 @@
                 },
                 "construction": {
                     "label": "Type"
+                },
+                "contact/webcam": {
+                    "label": "Webcam feed URL",
+                    "placeholder": "http://example.com/"
                 },
                 "content": {
                     "label": "Contents"
@@ -1528,6 +1544,18 @@
                 },
                 "surface": {
                     "label": "Surface"
+                },
+                "surveillance": {
+                    "label": "Surveillance kind",
+                    "placeholder": "Public, Outdoor, Indoor"
+                },
+                "surveillance/type": {
+                    "label": "What is watching",
+                    "placeholder": "Camera, Guard, ALPR"
+                },
+                "surveillance/zone": {
+                    "label": "Zone",
+                    "placeholder": "Town, Parking, Traffic, Shop, Building"
                 },
                 "tactile_paving": {
                     "label": "Tactile Paving"


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dsurveillance

These are mandatory tags:
* `surveillance`
* `surveillance:type`

These tags are well established:

* `camera:type` has 15k users
* `camera:mount` has 13k users
* `surveillance:zone` has 17k users (mostly traffic is noted)

These tags are in the proposed status:
* `contact:webcam` usage is only starting
* `camera:features` is rarely used currently
* `height`