### PR TITLE
data/presets: taxon, taxon:genus added to help identify plants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,13 @@ node_js:
   - "4"
   - "6"
 sudo: false
+
+script:
+  - npm test
+  - if ! git diff --patch --stat --color=never --exit-code; then
+        echo "";
+        echo "#### You can apply this patch via:";
+        echo "git apply -";
+        echo "git commit --all --message 'fix up generated files via \`npm run build\`'";
+        false;
+    fi >&2

--- a/data/presets/fields/taxon.json
+++ b/data/presets/fields/taxon.json
@@ -1,0 +1,6 @@
+{
+    "key": "taxon",
+    "type": "localized",
+    "label": "Taxonomical Name of Species",
+    "placeholder": "Scientific & Localized Names"
+}

--- a/data/presets/fields/taxon/genus.json
+++ b/data/presets/fields/taxon/genus.json
@@ -1,0 +1,6 @@
+{
+    "key": "taxon:genus",
+    "type": "text",
+    "label": "Taxonomic Genus of Species",
+    "placeholder": "Scientific Name of Genus"
+}

--- a/data/presets/presets/barrier/hedge.json
+++ b/data/presets/presets/barrier/hedge.json
@@ -1,4 +1,8 @@
 {
+    "fields": [
+        "taxon/genus",
+        "taxon"
+    ],
     "geometry": [
         "line",
         "area"

--- a/data/presets/presets/landuse/forest.json
+++ b/data/presets/presets/landuse/forest.json
@@ -1,6 +1,8 @@
 {
     "icon": "park2",
     "fields": [
+        "taxon/genus",
+        "taxon",
         "leaf_type",
         "leaf_cycle"
     ],

--- a/data/presets/presets/natural/heath.json
+++ b/data/presets/presets/natural/heath.json
@@ -1,4 +1,8 @@
 {
+    "fields": [
+        "taxon/genus",
+        "taxon"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/presets/natural/scrub.json
+++ b/data/presets/presets/natural/scrub.json
@@ -1,4 +1,8 @@
 {
+    "fields": [
+        "taxon/genus",
+        "taxon"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/presets/natural/tree.json
+++ b/data/presets/presets/natural/tree.json
@@ -1,5 +1,8 @@
 {
     "fields": [
+        "taxon/genus",
+        "taxon",
+        "height",
         "leaf_type_singular",
         "leaf_cycle_singular",
         "denotation"

--- a/data/presets/presets/natural/tree_row.json
+++ b/data/presets/presets/natural/tree_row.json
@@ -1,5 +1,8 @@
 {
     "fields": [
+        "taxon/genus",
+        "taxon",
+        "height",
         "leaf_type",
         "leaf_cycle",
         "denotation"

--- a/data/presets/presets/natural/wood.json
+++ b/data/presets/presets/natural/wood.json
@@ -1,6 +1,8 @@
 {
     "icon": "park2",
     "fields": [
+        "taxon/genus",
+        "taxon",
         "leaf_type",
         "leaf_cycle"
     ],


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Key:taxon

Add taxon to wood, tree*, hedge, forest, scrub, heath
(These were the kind of objects indicated at the definition)

Marsh was skipped because it is a deprecated tag and iD has no
preset for it.

Height is also a common tag for trees.